### PR TITLE
fix: Set 'query' to be the default param_type for Array on GET requests

### DIFF
--- a/lib/grape-swagger/doc_methods/parse_params.rb
+++ b/lib/grape-swagger/doc_methods/parse_params.rb
@@ -91,7 +91,7 @@ module GrapeSwagger
 
           array_items[:default] = value_type[:default] if value_type[:default].present?
 
-          @parsed_param[:in] = param_type || 'formData'
+          @parsed_param[:in] = param_type || value_type[:method] == 'GET' ? 'query' : 'formData'
           @parsed_param[:items] = array_items
           @parsed_param[:type] = 'array'
           @parsed_param[:collectionFormat] = collection_format if DataType.collections.include?(collection_format)


### PR DESCRIPTION
Swagger-UI does not allow any other params than of type `query` on GET requests, but arrays are always sent as `formData` unless specified explicitly in `documentation` hash, which produces useless complexity.